### PR TITLE
Add runtime option IGNORE_MIN_REQUIREMENTS to ignore system requirements check

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,15 @@ when the cluster is started. Example:
 echo "CREATE DATABASE test;" > schema.sql
 docker run -d -v $(PWD)/schema.sql:/schema.sql -p 3306:3306 -p 9000:9000 --name=memsql memsql/quickstart
 ```
+
+### Ignore system requirements check
+
+MemSQL is designed to run on machines with minimum systems requirements. Please read
+[this article](https://help.memsql.com/hc/en-us/articles/115001215583-My-hosts-have-less-than-minimum-MemSQL-system-requirements-How-can-I-make-MemSQL-run-on-those-hosts-) 
+to understand how disabling this check could lead to a less ideal experience. If you
+understand the risk you may disable the check by passing in a `IGNORE_MIN_REQUIREMENTS=1`
+Docker environment variable:
+
+```
+docker run -d -p 3306:3306 -p 9000:9000 --name=memsql -e IGNORE_MIN_REQUIREMENTS=1 memsql/quickstart
+```

--- a/memsql-entrypoint.sh
+++ b/memsql-entrypoint.sh
@@ -3,6 +3,12 @@ set -e
 
 if [[ "$1" = "memsqld" ]]; then
     memsql-ops start
+
+    if [[ "$IGNORE_MIN_REQUIREMENTS" = "1" ]]; then
+        memsql-ops memsql-update-config --all --key minimum_core_count --value 0
+        memsql-ops memsql-update-config --all --key minimum_memory_mb --value 0
+    fi
+
     memsql-ops memsql-start --all
     memsql-ops memsql-list
 


### PR DESCRIPTION
This change exposes an `IGNORE_MIN_REQUIREMENTS` Docker environment variable that allows the user to disable the minimum system requirements check. Per [this MemSQL article](https://help.memsql.com/hc/en-us/articles/115001215583-My-hosts-have-less-than-minimum-MemSQL-system-requirements-How-can-I-make-MemSQL-run-on-those-hosts-) this is not a recommended practice for development or production. I've added this caveat in the README so users are informed before choosing to ignore this check.

Implements https://github.com/memsql/memsql-docker-quickstart/issues/10

I don't believe this should be merged into `master` but I didn't see an unreleased branch. Let me know if this is a feature you're willing to accept and if there's a different approach you'd rather see.

Thanks for your time.