### PR TITLE
Wait until cluster is ready before connecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ docker run --rm memsql/quickstart check-system
 docker run -d -p 3306:3306 -p 9000:9000 --name=memsql memsql/quickstart
 
 
-# Wait until the cluster is ready before connecting to it.
-sleep 10
-
 # Run a quick benchmark against MemSQL
 docker run --rm -it --link=memsql:memsql memsql/quickstart simple-benchmark
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ docker run --rm memsql/quickstart check-system
 # Spin up a MemSQL cluster on your machine
 docker run -d -p 3306:3306 -p 9000:9000 --name=memsql memsql/quickstart
 
+# You might need to wait several seconds for your MemSQL cluster to start
+# before you can connect to it.
 
 # Run a quick benchmark against MemSQL
 docker run --rm -it --link=memsql:memsql memsql/quickstart simple-benchmark

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ docker run --rm memsql/quickstart check-system
 docker run -d -p 3306:3306 -p 9000:9000 --name=memsql memsql/quickstart
 
 
+# Wait until the cluster is ready before connecting to it.
+sleep 10
+
 # Run a quick benchmark against MemSQL
 docker run --rm -it --link=memsql:memsql memsql/quickstart simple-benchmark
 


### PR DESCRIPTION
Otherwise the user receives the following error:

Unable to connect to MemSQL with provided connection details.
Please verify that MemSQL is running @ 127.0.0.1:3306