### PR TITLE
Remove minimum core requirement by default. Because this is only mean…

### DIFF
--- a/memsql-entrypoint.sh
+++ b/memsql-entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 if [[ "$1" = "memsqld" ]]; then
     memsql-ops start
-
+    
+    #Eliminate Minimum Core Count Requirement
+    memsql-ops memsql-update-config --all --key minimum_core_count --value 0	
+    
     if [[ "$IGNORE_MIN_REQUIREMENTS" = "1" ]]; then
-        memsql-ops memsql-update-config --all --key minimum_core_count --value 0
         memsql-ops memsql-update-config --all --key minimum_memory_mb --value 0
     fi
 


### PR DESCRIPTION
…t for testing, we do not need to enforce the core requirement. This will allow more users to use the image and remove friction from the initial experience.